### PR TITLE
Fix outgoing mail search indexing

### DIFF
--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::commands::attachments::stage_local_attachment_records;
+use crate::commands::messages::refresh_search_document;
 use crate::commands::oauth::ensure_account_oauth_tokens;
 use crate::{events, state::AppState};
 use pebble_core::traits::{MailTransport, OutgoingMessage};
@@ -13,6 +14,7 @@ use pebble_mail::{smtp::SmtpSender, SmtpConfig};
 use pebble_mail::{GmailProvider, OutlookProvider};
 use pebble_store::Store;
 use tauri::{Emitter, State};
+use tracing::warn;
 
 /// Validate that all attachment paths are within allowed directories.
 pub(crate) fn validate_attachment_paths(
@@ -122,7 +124,7 @@ pub(crate) fn save_outgoing_message_locally(
     account: &Account,
     outgoing: &OutgoingMessage,
     state: LocalOutgoingState,
-    attachments_dir: &std::path::Path,
+    attachments_dir: &Path,
 ) -> std::result::Result<Message, PebbleError> {
     let folder = ensure_local_outgoing_folder(store, &account.id, state)?;
     let now = now_timestamp();
@@ -163,6 +165,26 @@ pub(crate) fn save_outgoing_message_locally(
     };
 
     store.replace_message_with_attachments(&message, &[folder.id], &attachments)?;
+    Ok(message)
+}
+
+fn save_outgoing_message_and_refresh_search(
+    state: &AppState,
+    account: &Account,
+    outgoing: &OutgoingMessage,
+    outgoing_state: LocalOutgoingState,
+    attachments_dir: &Path,
+) -> std::result::Result<Message, PebbleError> {
+    let message = save_outgoing_message_locally(
+        &state.store,
+        account,
+        outgoing,
+        outgoing_state,
+        attachments_dir,
+    )?;
+    if let Err(e) = refresh_search_document(state, &message.id) {
+        warn!("Failed to index outgoing message {}: {e}", message.id);
+    }
     Ok(message)
 }
 
@@ -271,7 +293,7 @@ fn queue_failed_send(
         LocalOutgoingState::Queued,
         &state.attachments_dir,
     )?;
-    state.store.insert_pending_mail_op(
+    let op_id = state.store.insert_pending_mail_op(
         &account.id,
         &message.id,
         "send",
@@ -284,7 +306,14 @@ fn queue_failed_send(
             },
         })
         .to_string(),
-    )
+    )?;
+    if let Err(e) = refresh_search_document(state, &message.id) {
+        warn!(
+            "Failed to index queued outgoing message {}: {e}",
+            message.id
+        );
+    }
+    Ok(op_id)
 }
 
 #[tauri::command]
@@ -358,8 +387,8 @@ pub async fn send_email(
 
     match send_imap_smtp_message(&state, &account, &outgoing).await {
         Ok(()) => {
-            save_outgoing_message_locally(
-                &state.store,
+            save_outgoing_message_and_refresh_search(
+                &state,
                 &account,
                 &outgoing,
                 LocalOutgoingState::Sent,
@@ -379,7 +408,9 @@ pub async fn send_email(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::messages::refresh_search_document_with_store;
     use pebble_core::{now_timestamp, Account, FolderRole};
+    use pebble_search::TantivySearch;
     use pebble_store::Store;
 
     fn test_account() -> Account {
@@ -472,6 +503,31 @@ mod tests {
         assert!(outbox.role.is_none());
         assert_eq!(folder_ids, vec![outbox.id]);
         assert!(saved.remote_id.starts_with("local-outbox-"));
+
+        let _ = std::fs::remove_dir_all(attachments_dir);
+    }
+
+    #[test]
+    fn locally_saved_outgoing_message_can_be_added_to_search_index() {
+        let store = Store::open_in_memory().unwrap();
+        let account = test_account();
+        store.insert_account(&account).unwrap();
+        let attachments_dir = temp_attachments_dir("pebble-outgoing-search");
+        let search = TantivySearch::open_in_memory().unwrap();
+
+        let saved = save_outgoing_message_locally(
+            &store,
+            &account,
+            &outgoing_message(),
+            LocalOutgoingState::Sent,
+            &attachments_dir,
+        )
+        .unwrap();
+        refresh_search_document_with_store(&store, &search, &saved.id).unwrap();
+
+        let hits = search.search("Queued", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].message_id, saved.id);
 
         let _ = std::fs::remove_dir_all(attachments_dir);
     }

--- a/src-tauri/src/commands/messages/mod.rs
+++ b/src-tauri/src/commands/messages/mod.rs
@@ -11,6 +11,7 @@ use crate::state::AppState;
 use pebble_core::{FolderRole, Message, PebbleError};
 use pebble_crypto::CryptoService;
 use pebble_mail::{GmailProvider, ImapConfig, ImapProvider, OutlookProvider};
+use pebble_search::TantivySearch;
 use pebble_store::Store;
 use serde_json::json;
 
@@ -93,29 +94,37 @@ pub(super) async fn connect_outlook(
     ))
 }
 
-pub(super) fn refresh_search_document(
+pub(crate) fn refresh_search_document(
     state: &AppState,
     message_id: &str,
 ) -> std::result::Result<(), PebbleError> {
-    let ids = vec![message_id.to_string()];
-    state.store.add_search_pending(&ids, "index")?;
+    refresh_search_document_with_store(&state.store, &state.search, message_id)
+}
 
-    match state.store.get_message(message_id)? {
+pub(crate) fn refresh_search_document_with_store(
+    store: &Store,
+    search: &TantivySearch,
+    message_id: &str,
+) -> std::result::Result<(), PebbleError> {
+    let ids = vec![message_id.to_string()];
+    store.add_search_pending(&ids, "index")?;
+
+    match store.get_message(message_id)? {
         Some(message) if !message.is_deleted => {
-            let folder_ids = state.store.get_message_folder_ids(message_id)?;
+            let folder_ids = store.get_message_folder_ids(message_id)?;
             if folder_ids.is_empty() {
-                state.search.remove_message(message_id)?;
+                search.remove_message(message_id)?;
             } else {
-                state.search.index_message(&message, &folder_ids)?;
+                search.index_message(&message, &folder_ids)?;
             }
         }
         Some(_) | None => {
-            state.search.remove_message(message_id)?;
+            search.remove_message(message_id)?;
         }
     }
 
-    state.search.commit()?;
-    state.store.clear_search_pending(&ids)?;
+    search.commit()?;
+    store.clear_search_pending(&ids)?;
     Ok(())
 }
 


### PR DESCRIPTION
 ## 问题描述                                                                                                                                                                         
                                                                                                                                                                                      
  IMAP/SMTP 账户发送邮件后，邮件会立即保存到本地“已发送”并可以正常打开，但无法立即通过搜索找到。删除 `search_index` 并重建索引后，该邮件才能被搜索到。
                                                                                                                                                                                        ## 复现步骤
                                                                                                                                                                                      
  1. 使用 IMAP/SMTP 账户发送一封邮件：                                                                                                                                                
     - 主题：`Hello`
     - 正文：`你好啊`
  2. 发送成功后，在“已发送”中确认该邮件存在。
  3. 进入搜索页，搜索：
     ```text
     Hello
  实际结果

  刚发送的邮件没有出现在搜索结果中。

  预期结果

  刚发送并保存到本地的邮件应立即加入搜索索引，可以直接被搜索到。

  发送失败并进入本地 Outbox / pending op 的邮件也应可以被搜索到。

  初步原因

  发送路径会调用 save_outgoing_message_locally(...) 将邮件写入 SQLite，但没有同步刷新 Tantivy 搜索索引，例如调用 refresh_search_document(...)。

  因此邮件存在于数据库中，但搜索索引中没有对应文档。