### PR TITLE
docs: add installation instructions for Arch Linux AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ Pebble currently supports Gmail, IMAP, and experimental Outlook accounts.
 
 ## Getting Started
 
+### Install
+
+Download prebuilt desktop packages from the [Releases](https://github.com/QingJ01/Pebble/releases) page.
+
+On Arch Linux, Pebble is available from the AUR as `pebble-bin`:
+
+```bash
+yay -S pebble-bin
+# or
+paru -S pebble-bin
+```
+
 ### Prerequisites
 
 - Rust stable

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,6 +94,18 @@ Pebble 目前支持 Gmail、IMAP，以及实验性的 Outlook 账户。
 
 ## 开始使用
 
+### 安装
+
+你可以从 [发布版本](https://github.com/QingJ01/Pebble/releases) 页面下载预构建的桌面安装包。
+
+Arch Linux 用户可以通过 AUR 安装 `pebble-bin`：
+
+```bash
+yay -S pebble-bin
+# 或者
+paru -S pebble-bin
+```
+
 ### 环境要求
 
 - Rust stable


### PR DESCRIPTION
This PR adds Arch Linux / AUR installation instructions for Pebble.

Users can now install the prebuilt Linux AppImage package with either:

```bash
yay -S pebble-bin
# or
paru -S pebble-bin
```

## AUR package maintenance

The `pebble-bin` package is maintained through an automated updater repository:

https://github.com/cyole/aur-pebble-bin-updater

The updater checks Pebble GitHub Releases hourly and updates the AUR package when a new Linux AppImage release is available.