### PR TITLE
tests(useCloseToBackground): mock sync APIs and add focus/resume and stop-on-hide tests

### DIFF
--- a/tests/app/useCloseToBackground.test.tsx
+++ b/tests/app/useCloseToBackground.test.tsx
@@ -1,15 +1,24 @@
 import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startSync, stopSync } from "../../src/lib/api";
 
 const mocks = vi.hoisted(() => ({
+  accounts: [{ id: "account-1" }, { id: "account-2" }],
   closeHandler: undefined as undefined | ((event: { preventDefault: () => void }) => void | Promise<void>),
+  focusHandler: undefined as undefined | ((event: { payload: boolean }) => void),
   hide: vi.fn().mockResolvedValue(undefined),
   onCloseRequested: vi.fn((handler: (event: { preventDefault: () => void }) => void | Promise<void>) => {
     mocks.closeHandler = handler;
     return Promise.resolve(vi.fn());
   }),
+  onFocusChanged: vi.fn((handler: (event: { payload: boolean }) => void) => {
+    mocks.focusHandler = handler;
+    return Promise.resolve(vi.fn());
+  }),
   uiState: {
     keepRunningInBackground: false,
+    pollInterval: 5,
+    realtimeMode: "realtime" as "realtime" | "balanced" | "battery" | "manual",
   },
 }));
 
@@ -17,14 +26,24 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     hide: mocks.hide,
     onCloseRequested: mocks.onCloseRequested,
+    onFocusChanged: mocks.onFocusChanged,
   }),
 }));
 
-vi.mock("../../src/stores/ui.store", () => ({
-  useUIStore: {
-    getState: () => mocks.uiState,
-  },
+vi.mock("../../src/lib/api", () => ({
+  startSync: vi.fn().mockResolvedValue(undefined),
+  stopSync: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock("../../src/hooks/queries", () => ({
+  useAccountsQuery: () => ({ data: mocks.accounts }),
+}));
+
+vi.mock("../../src/stores/ui.store", () => {
+  const useUIStore = (selector: (state: typeof mocks.uiState) => unknown) => selector(mocks.uiState);
+  useUIStore.getState = () => mocks.uiState;
+  return { useUIStore };
+});
 
 import { useCloseToBackground } from "../../src/app/useCloseToBackground";
 
@@ -37,7 +56,11 @@ describe("useCloseToBackground", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.closeHandler = undefined;
+    mocks.focusHandler = undefined;
+    mocks.accounts = [{ id: "account-1" }, { id: "account-2" }];
     mocks.uiState.keepRunningInBackground = false;
+    mocks.uiState.pollInterval = 5;
+    mocks.uiState.realtimeMode = "realtime";
   });
 
   it("lets the app close normally when background mode is disabled", async () => {
@@ -61,5 +84,27 @@ describe("useCloseToBackground", () => {
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(mocks.hide).toHaveBeenCalledOnce();
+    await waitFor(() => expect(stopSync).toHaveBeenCalledWith("account-1"));
+    expect(stopSync).toHaveBeenCalledWith("account-2");
+  });
+
+  it("resumes sync when the hidden window regains focus", async () => {
+    render(<Harness />);
+
+    await waitFor(() => expect(mocks.onFocusChanged).toHaveBeenCalledOnce());
+    mocks.focusHandler?.({ payload: true });
+
+    expect(startSync).toHaveBeenCalledWith("account-1", 5);
+    expect(startSync).toHaveBeenCalledWith("account-2", 5);
+  });
+
+  it("does not resume sync in manual realtime mode", async () => {
+    mocks.uiState.realtimeMode = "manual";
+    render(<Harness />);
+
+    await waitFor(() => expect(mocks.onFocusChanged).toHaveBeenCalledOnce());
+    mocks.focusHandler?.({ payload: true });
+
+    expect(startSync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure the window-close-to-background behavior properly stops and resumes account synchronization and respects realtime mode and poll interval settings.

### Description

- Add mocks for `startSync` and `stopSync` and a `useAccountsQuery` mock so tests can assert per-account sync calls. 
- Mock the window `onFocusChanged` handler and extend the mocked `uiState` with `pollInterval` and `realtimeMode`, and refactor `useUIStore` mock to use a selector-based `getState`. 
- Add assertions that `stopSync` is called for each account when the app is hidden instead of closed. 
- Add tests that `startSync` is invoked with each account and the configured `pollInterval` when the hidden window regains focus, and that no resume occurs when `realtimeMode` is `manual`.

### Testing

- Ran the updated unit tests for `tests/app/useCloseToBackground.test.tsx` with `vitest`, and they passed.
- Ran the test suite including the updated mocks and focused scenarios, and all related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ffd86d6d083259d490a2fd90f903a)