### PR TITLE
feat(mail): show CC recipients and select IMAP sync folders

### DIFF
--- a/crates/pebble-mail/src/sync.rs
+++ b/crates/pebble-mail/src/sync.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -406,6 +407,21 @@ fn should_attempt_imap_remote_folder(folder: &pebble_core::Folder) -> bool {
     !folder.remote_id.starts_with("__local_")
 }
 
+fn should_include_discovered_imap_folder(
+    folder: &pebble_core::Folder,
+    selected_remote_ids: Option<&HashSet<String>>,
+) -> bool {
+    let Some(selected_remote_ids) = selected_remote_ids else {
+        // Existing accounts without an explicit preference retain the legacy
+        // behaviour of syncing every selectable mailbox.
+        return true;
+    };
+
+    folder.role == Some(pebble_core::FolderRole::Inbox)
+        || folder.remote_id.eq_ignore_ascii_case("INBOX")
+        || selected_remote_ids.contains(&folder.remote_id)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ImapPollScope {
     Realtime,
@@ -784,11 +800,32 @@ impl SyncWorker {
     pub async fn initial_sync(&self) -> Result<()> {
         info!("Starting initial sync for account {}", self.base.account_id);
 
-        let remote_folders = self
+        let selected_remote_ids = self
+            .base
+            .store
+            .get_sync_state(&self.base.account_id)?
+            .and_then(|state| state.selected_imap_folder_remote_ids)
+            .map(|ids| ids.into_iter().collect::<HashSet<_>>());
+
+        let discovered_folders = self
             .provider
             .inner()
             .list_folders(&self.base.account_id)
             .await?;
+        let remote_folders: Vec<_> = discovered_folders
+            .into_iter()
+            .filter(|folder| {
+                should_include_discovered_imap_folder(folder, selected_remote_ids.as_ref())
+            })
+            .collect();
+
+        if selected_remote_ids.is_some() {
+            info!(
+                "Applying explicit IMAP folder selection for account {} ({} folders including Inbox)",
+                self.base.account_id,
+                remote_folders.len()
+            );
+        }
 
         for folder in &remote_folders {
             // Upsert folder into store
@@ -1219,8 +1256,9 @@ impl SyncWorker {
 
         let cursor = self.try_imap_folder_cursor_for_sync(folder).await?;
         let since_uid = cursor.last_uid;
+        let limit = if since_uid.is_some() { 50 } else { 200 };
 
-        let count = self.sync_folder(folder, since_uid, 50, true).await?;
+        let count = self.sync_folder(folder, since_uid, limit, true).await?;
         if count > 0 {
             info!(
                 "Polled {} new messages from {} for account {}",
@@ -2226,6 +2264,36 @@ mod tests {
         assert!(!should_poll_imap_folder_for_realtime(&sent));
         assert!(!should_poll_imap_folder_for_realtime(&spam));
         assert!(!should_poll_imap_folder_for_realtime(&custom));
+    }
+
+    #[test]
+    fn explicit_imap_selection_always_includes_inbox() {
+        let inbox = test_folder(Some(pebble_core::FolderRole::Inbox), "INBOX");
+        let sent = test_folder(Some(pebble_core::FolderRole::Sent), "Sent");
+        let custom = test_folder(None, "Newsletters");
+        let selected = HashSet::from(["Newsletters".to_string()]);
+
+        assert!(should_include_discovered_imap_folder(
+            &inbox,
+            Some(&selected)
+        ));
+        assert!(!should_include_discovered_imap_folder(
+            &sent,
+            Some(&selected)
+        ));
+        assert!(should_include_discovered_imap_folder(
+            &custom,
+            Some(&selected)
+        ));
+    }
+
+    #[test]
+    fn missing_imap_selection_preserves_legacy_all_folder_sync() {
+        let sent = test_folder(Some(pebble_core::FolderRole::Sent), "Sent");
+        let custom = test_folder(None, "Newsletters");
+
+        assert!(should_include_discovered_imap_folder(&sent, None));
+        assert!(should_include_discovered_imap_folder(&custom, None));
     }
 
     #[test]

--- a/crates/pebble-store/src/accounts.rs
+++ b/crates/pebble-store/src/accounts.rs
@@ -32,6 +32,14 @@ pub struct SyncState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smtp: Option<serde_json::Value>,
 
+    /// Explicit IMAP mailbox selection, stored as provider remote IDs.
+    ///
+    /// `None` preserves the legacy behaviour of syncing every selectable
+    /// mailbox. `Some(...)` enables account-level selection; Inbox is always
+    /// included by the IMAP worker even when it is absent from this list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_imap_folder_remote_ids: Option<Vec<String>>,
+
     /// Any fields we don't yet model — preserved verbatim on write so
     /// round-tripping through [`Store::update_sync_state`] never drops data.
     #[serde(flatten)]

--- a/crates/pebble-store/src/folders.rs
+++ b/crates/pebble-store/src/folders.rs
@@ -1,7 +1,18 @@
-use pebble_core::{Folder, FolderRole, FolderType, Result};
+use pebble_core::{Folder, FolderRole, FolderType, PebbleError, Result};
 use rusqlite::{params, OptionalExtension};
+use std::collections::{BTreeSet, HashSet};
 
-use crate::Store;
+use crate::{accounts::SyncState, Store};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImapFolderSelectionChange {
+    /// Messages whose folder membership changed and whose search documents
+    /// therefore need to be refreshed.
+    pub affected_message_ids: Vec<String>,
+    /// Messages that no longer belong to any folder and were physically
+    /// removed along with their attachment records.
+    pub deleted_message_ids: Vec<String>,
+}
 
 fn folder_type_to_str(ft: &FolderType) -> &'static str {
     match ft {
@@ -172,5 +183,340 @@ impl Store {
             }
             Ok(folders)
         })
+    }
+
+    /// Atomically persist an explicit IMAP mailbox selection, upsert the
+    /// selected remote folders, and remove local data for deselected remote
+    /// folders. Local-only folders (whose remote ID starts with `__local_`) are
+    /// intentionally retained.
+    pub fn apply_imap_folder_selection(
+        &self,
+        account_id: &str,
+        remote_folders: &[Folder],
+        selected_remote_ids: &[String],
+    ) -> Result<ImapFolderSelectionChange> {
+        if remote_folders
+            .iter()
+            .any(|folder| folder.account_id != account_id)
+        {
+            return Err(PebbleError::Validation(
+                "IMAP folder selection contains a folder for another account".to_string(),
+            ));
+        }
+
+        let mut selected_ordered = Vec::with_capacity(selected_remote_ids.len());
+        let mut seen = HashSet::with_capacity(selected_remote_ids.len());
+        for remote_id in selected_remote_ids {
+            if seen.insert(remote_id.clone()) {
+                selected_ordered.push(remote_id.clone());
+            }
+        }
+        let selected: HashSet<String> = selected_ordered.iter().cloned().collect();
+
+        self.with_write(|conn| {
+            let tx = conn.unchecked_transaction()?;
+
+            let raw_sync_state: Option<Option<String>> = tx
+                .query_row(
+                    "SELECT sync_state FROM accounts WHERE id = ?1",
+                    params![account_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            let Some(raw_sync_state) = raw_sync_state else {
+                return Err(PebbleError::Internal(format!(
+                    "Account not found: {account_id}"
+                )));
+            };
+            let mut sync_state = SyncState::from_json_opt(raw_sync_state.as_deref())?;
+            sync_state.selected_imap_folder_remote_ids = Some(selected_ordered);
+            let sync_state_json = sync_state.to_json()?;
+
+            for folder in remote_folders
+                .iter()
+                .filter(|folder| selected.contains(&folder.remote_id))
+            {
+                let existing_id: Option<String> = tx
+                    .query_row(
+                        "SELECT id FROM folders WHERE account_id = ?1 AND remote_id = ?2",
+                        params![account_id, folder.remote_id],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+
+                if let Some(existing_id) = existing_id {
+                    tx.execute(
+                        "UPDATE folders
+                         SET name = ?1, folder_type = ?2, role = ?3, parent_id = ?4,
+                             color = ?5, is_system = ?6, sort_order = ?7
+                         WHERE id = ?8",
+                        params![
+                            folder.name,
+                            folder_type_to_str(&folder.folder_type),
+                            folder.role.as_ref().map(folder_role_to_str),
+                            folder.parent_id,
+                            folder.color,
+                            folder.is_system as i32,
+                            folder.sort_order,
+                            existing_id,
+                        ],
+                    )?;
+                } else {
+                    tx.execute(
+                        "INSERT INTO folders
+                         (id, account_id, remote_id, name, folder_type, role,
+                          parent_id, color, is_system, sort_order)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                        params![
+                            folder.id,
+                            account_id,
+                            folder.remote_id,
+                            folder.name,
+                            folder_type_to_str(&folder.folder_type),
+                            folder.role.as_ref().map(folder_role_to_str),
+                            folder.parent_id,
+                            folder.color,
+                            folder.is_system as i32,
+                            folder.sort_order,
+                        ],
+                    )?;
+                }
+            }
+
+            let stored_remote_folders = {
+                let mut stmt = tx.prepare(
+                    "SELECT id, remote_id FROM folders
+                     WHERE account_id = ?1",
+                )?;
+                let rows = stmt.query_map(params![account_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                let mut folders = Vec::new();
+                for row in rows {
+                    folders.push(row?);
+                }
+                folders
+            };
+
+            let removed_folder_ids: Vec<String> = stored_remote_folders
+                .into_iter()
+                .filter(|(_, remote_id)| {
+                    !remote_id.starts_with("__local_") && !selected.contains(remote_id)
+                })
+                .map(|(id, _)| id)
+                .collect();
+            let mut affected_message_ids = BTreeSet::new();
+
+            for folder_id in &removed_folder_ids {
+                let message_ids = {
+                    let mut stmt =
+                        tx.prepare("SELECT message_id FROM message_folders WHERE folder_id = ?1")?;
+                    let rows = stmt.query_map(params![folder_id], |row| row.get::<_, String>(0))?;
+                    let mut ids = Vec::new();
+                    for row in rows {
+                        ids.push(row?);
+                    }
+                    ids
+                };
+                affected_message_ids.extend(message_ids);
+
+                // Delete the junction rows explicitly so cleanup remains
+                // correct even on a connection where SQLite FK cascades were
+                // not enabled by an older application build.
+                tx.execute(
+                    "DELETE FROM message_folders WHERE folder_id = ?1",
+                    params![folder_id],
+                )?;
+                tx.execute("DELETE FROM folders WHERE id = ?1", params![folder_id])?;
+            }
+
+            let mut deleted_message_ids = Vec::new();
+            for message_id in &affected_message_ids {
+                let remaining_folder_count: i64 = tx.query_row(
+                    "SELECT COUNT(*) FROM message_folders WHERE message_id = ?1",
+                    params![message_id],
+                    |row| row.get(0),
+                )?;
+                if remaining_folder_count == 0 {
+                    tx.execute("DELETE FROM messages WHERE id = ?1", params![message_id])?;
+                    deleted_message_ids.push(message_id.clone());
+                }
+            }
+
+            tx.execute(
+                "UPDATE accounts SET sync_state = ?1, updated_at = ?2 WHERE id = ?3",
+                params![sync_state_json, pebble_core::now_timestamp(), account_id],
+            )?;
+
+            tx.commit()?;
+            Ok(ImapFolderSelectionChange {
+                affected_message_ids: affected_message_ids.into_iter().collect(),
+                deleted_message_ids,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pebble_core::{now_timestamp, Account, EmailAddress, Message, ProviderType};
+
+    fn account() -> Account {
+        let now = now_timestamp();
+        Account {
+            id: "account-1".to_string(),
+            email: "user@example.com".to_string(),
+            display_name: "User".to_string(),
+            color: None,
+            provider: ProviderType::Imap,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn folder(account_id: &str, id: &str, remote_id: &str, role: Option<FolderRole>) -> Folder {
+        Folder {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            remote_id: remote_id.to_string(),
+            name: remote_id.to_string(),
+            folder_type: FolderType::Folder,
+            role,
+            parent_id: None,
+            color: None,
+            is_system: true,
+            sort_order: 0,
+        }
+    }
+
+    fn message(account_id: &str, id: &str, remote_id: &str) -> Message {
+        let now = now_timestamp();
+        Message {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            remote_id: remote_id.to_string(),
+            message_id_header: None,
+            in_reply_to: None,
+            references_header: None,
+            thread_id: None,
+            subject: id.to_string(),
+            snippet: String::new(),
+            from_address: "sender@example.com".to_string(),
+            from_name: "Sender".to_string(),
+            to_list: vec![EmailAddress {
+                name: None,
+                address: "user@example.com".to_string(),
+            }],
+            cc_list: vec![],
+            bcc_list: vec![],
+            body_text: String::new(),
+            body_html_raw: String::new(),
+            has_attachments: false,
+            is_read: false,
+            is_starred: false,
+            is_draft: false,
+            date: now,
+            remote_version: None,
+            is_deleted: false,
+            deleted_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn applying_imap_selection_adds_and_removes_folders_and_cleans_orphans() {
+        let store = Store::open_in_memory().unwrap();
+        let account = account();
+        store.insert_account(&account).unwrap();
+        store
+            .update_account_sync_state(
+                &account.id,
+                r#"{"provider":"imap","custom_setting":"preserved"}"#,
+            )
+            .unwrap();
+
+        let inbox = folder(
+            &account.id,
+            "folder-inbox",
+            "INBOX",
+            Some(FolderRole::Inbox),
+        );
+        let removed = folder(&account.id, "folder-projects", "Projects", None);
+        let local_archive = folder(
+            &account.id,
+            "folder-local-archive",
+            "__local_archive__",
+            Some(FolderRole::Archive),
+        );
+        store.insert_folder(&inbox).unwrap();
+        store.insert_folder(&removed).unwrap();
+        store.insert_folder(&local_archive).unwrap();
+
+        let removed_only = message(&account.id, "message-removed", "100");
+        let shared = message(&account.id, "message-shared", "101");
+        store
+            .insert_message(&removed_only, std::slice::from_ref(&removed.id))
+            .unwrap();
+        store
+            .insert_message(&shared, &[removed.id.clone(), inbox.id.clone()])
+            .unwrap();
+
+        let fresh_inbox = folder(
+            &account.id,
+            "fresh-inbox-id",
+            "INBOX",
+            Some(FolderRole::Inbox),
+        );
+        let fresh_removed = folder(&account.id, "fresh-project-id", "Projects", None);
+        let fresh_added = folder(&account.id, "fresh-team-id", "Team", None);
+        let change = store
+            .apply_imap_folder_selection(
+                &account.id,
+                &[fresh_inbox, fresh_removed, fresh_added],
+                &["INBOX".to_string(), "Team".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            change.affected_message_ids,
+            vec!["message-removed".to_string(), "message-shared".to_string()]
+        );
+        assert_eq!(
+            change.deleted_message_ids,
+            vec!["message-removed".to_string()]
+        );
+        assert!(store.get_message("message-removed").unwrap().is_none());
+        assert!(store.get_message("message-shared").unwrap().is_some());
+        assert_eq!(
+            store.get_message_folder_ids("message-shared").unwrap(),
+            vec![inbox.id]
+        );
+
+        let stored_remote_ids: HashSet<String> = store
+            .list_folders(&account.id)
+            .unwrap()
+            .into_iter()
+            .map(|folder| folder.remote_id)
+            .collect();
+        assert_eq!(
+            stored_remote_ids,
+            HashSet::from([
+                "INBOX".to_string(),
+                "Team".to_string(),
+                "__local_archive__".to_string(),
+            ])
+        );
+
+        let state = store.get_sync_state(&account.id).unwrap().unwrap();
+        assert_eq!(
+            state.selected_imap_folder_remote_ids,
+            Some(vec!["INBOX".to_string(), "Team".to_string()])
+        );
+        assert_eq!(
+            state.extra.get("custom_setting"),
+            Some(&serde_json::Value::String("preserved".to_string()))
+        );
     }
 }

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -406,7 +406,7 @@ pub async fn add_account(
         state.store.set_auth_data(&account.id, &encrypted)?;
 
         // Store non-secret metadata in sync_state
-        let provider_slug = match provider {
+        let provider_slug = match &provider {
             ProviderType::Gmail => "gmail",
             ProviderType::Outlook => "outlook",
             ProviderType::Pop3 => "pop3",
@@ -414,6 +414,12 @@ pub async fn add_account(
         };
         state.store.update_sync_state(&account.id, |s| {
             s.provider = Some(provider_slug.to_string());
+            // New IMAP accounts start with Inbox only. Users can opt into
+            // additional mailboxes from the account editor after the account
+            // exists and its saved credentials can be used for IMAP LIST.
+            if provider == ProviderType::Imap {
+                s.selected_imap_folder_remote_ids = Some(Vec::new());
+            }
         })?;
         Ok(())
     })() {

--- a/src-tauri/src/commands/appearance.rs
+++ b/src-tauri/src/commands/appearance.rs
@@ -47,7 +47,8 @@ fn validate_background_image_bytes(bytes: &[u8]) -> Result<&'static str, PebbleE
 }
 
 fn background_images_dir(app: &AppHandle) -> Result<PathBuf, PebbleError> {
-    let app_data = crate::profile::require_managed_app_data_dir(app).map_err(PebbleError::Internal)?;
+    let app_data =
+        crate::profile::require_managed_app_data_dir(app).map_err(PebbleError::Internal)?;
     Ok(app_data.join("backgrounds"))
 }
 

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -1,7 +1,15 @@
 use crate::state::AppState;
 use pebble_core::{new_id, Folder, FolderRole, FolderType, PebbleError, ProviderType};
 use pebble_mail::should_hide_outlook_folder;
+use serde::Serialize;
+use std::collections::HashSet;
 use tauri::State;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImapSyncFolderSettings {
+    pub folders: Vec<Folder>,
+    pub selected_remote_ids: Vec<String>,
+}
 
 fn provider_folders_have_arrived(folders: &[Folder]) -> bool {
     folders
@@ -76,6 +84,159 @@ pub async fn list_folders(
     })
     .await
     .map_err(|e| PebbleError::Internal(format!("Task join error: {e}")))?
+}
+
+async fn discover_imap_folders(
+    state: &AppState,
+    account_id: &str,
+) -> std::result::Result<Vec<Folder>, PebbleError> {
+    let account = state
+        .store
+        .get_account(account_id)?
+        .ok_or_else(|| PebbleError::Internal(format!("Account not found: {account_id}")))?;
+    if account.provider != ProviderType::Imap {
+        return Err(PebbleError::UnsupportedProvider(
+            "Folder selection is currently available for IMAP accounts".to_string(),
+        ));
+    }
+
+    let provider = crate::commands::messages::connect_imap(state, account_id).await?;
+    let result = provider.list_folders(account_id).await;
+    if let Err(error) = provider.disconnect().await {
+        tracing::debug!(
+            "Failed to disconnect IMAP folder discovery session for account {account_id}: {error}"
+        );
+    }
+    result
+}
+
+fn selected_remote_ids_for_settings(
+    folders: &[Folder],
+    configured: Option<Vec<String>>,
+) -> Vec<String> {
+    let configured = configured.map(|ids| ids.into_iter().collect::<HashSet<_>>());
+    folders
+        .iter()
+        .filter(|folder| {
+            folder.role == Some(FolderRole::Inbox)
+                || folder.remote_id.eq_ignore_ascii_case("INBOX")
+                || configured
+                    .as_ref()
+                    .is_none_or(|selected| selected.contains(&folder.remote_id))
+        })
+        .map(|folder| folder.remote_id.clone())
+        .collect()
+}
+
+#[tauri::command]
+pub async fn get_imap_sync_folders(
+    state: State<'_, AppState>,
+    account_id: String,
+) -> std::result::Result<ImapSyncFolderSettings, PebbleError> {
+    let folders = discover_imap_folders(&state, &account_id).await?;
+    let configured = state
+        .store
+        .get_sync_state(&account_id)?
+        .and_then(|sync_state| sync_state.selected_imap_folder_remote_ids);
+    let selected_remote_ids = selected_remote_ids_for_settings(&folders, configured);
+
+    Ok(ImapSyncFolderSettings {
+        folders,
+        selected_remote_ids,
+    })
+}
+
+#[tauri::command]
+pub async fn update_imap_sync_folders(
+    state: State<'_, AppState>,
+    account_id: String,
+    selected_remote_ids: Vec<String>,
+) -> std::result::Result<ImapSyncFolderSettings, PebbleError> {
+    // Refresh LIST when saving as well as when opening the picker. This avoids
+    // persisting stale or fabricated remote IDs when the server changed while
+    // the account dialog was open.
+    let folders = discover_imap_folders(&state, &account_id).await?;
+    let available_remote_ids: HashSet<&str> = folders
+        .iter()
+        .map(|folder| folder.remote_id.as_str())
+        .collect();
+    let unknown_remote_ids: Vec<&str> = selected_remote_ids
+        .iter()
+        .map(String::as_str)
+        .filter(|remote_id| !available_remote_ids.contains(remote_id))
+        .collect();
+    if !unknown_remote_ids.is_empty() {
+        return Err(PebbleError::Validation(format!(
+            "Unknown IMAP folders: {}",
+            unknown_remote_ids.join(", ")
+        )));
+    }
+
+    let requested: HashSet<&str> = selected_remote_ids.iter().map(String::as_str).collect();
+    let effective_selected_remote_ids: Vec<String> = folders
+        .iter()
+        .filter(|folder| {
+            folder.role == Some(FolderRole::Inbox)
+                || folder.remote_id.eq_ignore_ascii_case("INBOX")
+                || requested.contains(folder.remote_id.as_str())
+        })
+        .map(|folder| folder.remote_id.clone())
+        .collect();
+    if !folders.iter().any(|folder| {
+        folder.role == Some(FolderRole::Inbox) || folder.remote_id.eq_ignore_ascii_case("INBOX")
+    }) {
+        return Err(PebbleError::Validation(
+            "The IMAP server did not return an Inbox folder".to_string(),
+        ));
+    }
+
+    let store = state.store.clone();
+    let account_id_for_store = account_id.clone();
+    let folders_for_store = folders.clone();
+    let selected_for_store = effective_selected_remote_ids.clone();
+    let change = tokio::task::spawn_blocking(move || {
+        store.apply_imap_folder_selection(
+            &account_id_for_store,
+            &folders_for_store,
+            &selected_for_store,
+        )
+    })
+    .await
+    .map_err(|error| PebbleError::Internal(format!("Task join error: {error}")))??;
+
+    if let Err(error) =
+        crate::commands::messages::refresh_search_documents(&state, &change.affected_message_ids)
+    {
+        tracing::warn!(
+            "Failed to refresh search documents after changing IMAP folders for account {account_id}: {error}"
+        );
+    }
+
+    let attachments_dir = state.attachments_dir.clone();
+    let deleted_message_ids = change.deleted_message_ids;
+    if let Err(error) = tokio::task::spawn_blocking(move || {
+        for message_id in deleted_message_ids {
+            let message_dir = attachments_dir.join(&message_id);
+            if message_dir.exists() {
+                if let Err(error) = std::fs::remove_dir_all(&message_dir) {
+                    tracing::warn!(
+                        "Failed to remove attachments for deselected-folder message {message_id}: {error}"
+                    );
+                }
+            }
+        }
+    })
+    .await
+    {
+        tracing::warn!(
+            "Attachment cleanup task failed after changing IMAP folders for account {account_id}: {error}"
+        );
+    }
+
+    Ok(ImapSyncFolderSettings {
+        folders,
+        selected_remote_ids: effective_selected_remote_ids,
+    })
 }
 
 #[cfg(test)]
@@ -155,6 +316,35 @@ mod tests {
                 .map(|folder| folder.remote_id.as_str())
                 .collect::<Vec<_>>(),
             vec!["__local_outbox__", "inbox-id"]
+        );
+    }
+
+    #[test]
+    fn explicit_imap_folder_settings_keep_inbox_selected() {
+        let inbox = folder(FolderRole::Inbox, "INBOX");
+        let sent = folder(FolderRole::Sent, "Sent");
+        let mut custom = folder(FolderRole::Archive, "Newsletters");
+        custom.role = None;
+
+        let selected = selected_remote_ids_for_settings(
+            &[inbox, sent, custom],
+            Some(vec!["Newsletters".to_string()]),
+        );
+
+        assert_eq!(
+            selected,
+            vec!["INBOX".to_string(), "Newsletters".to_string()]
+        );
+    }
+
+    #[test]
+    fn legacy_imap_folder_settings_select_every_discovered_folder() {
+        let inbox = folder(FolderRole::Inbox, "INBOX");
+        let sent = folder(FolderRole::Sent, "Sent");
+
+        assert_eq!(
+            selected_remote_ids_for_settings(&[inbox, sent], None),
+            vec!["INBOX".to_string(), "Sent".to_string()]
         );
     }
 }

--- a/src-tauri/src/commands/messages/mod.rs
+++ b/src-tauri/src/commands/messages/mod.rs
@@ -148,7 +148,7 @@ pub(super) fn remove_search_documents(
 /// Use this instead of calling `refresh_search_document` in a loop: one commit
 /// for N messages is dramatically cheaper than N commits (segment flush +
 /// reader reload per doc).
-pub(super) fn refresh_search_documents(
+pub(crate) fn refresh_search_documents(
     state: &AppState,
     message_ids: &[String],
 ) -> std::result::Result<(), PebbleError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -502,6 +502,8 @@ pub fn run() {
             commands::accounts::test_pop3_connection,
             commands::accounts::test_account_connection,
             commands::folders::list_folders,
+            commands::folders::get_imap_sync_folders,
+            commands::folders::update_imap_sync_folders,
             commands::messages::query::list_messages,
             commands::messages::query::list_starred_messages,
             commands::messages::query::get_message,

--- a/src/components/MessageDetail.tsx
+++ b/src/components/MessageDetail.tsx
@@ -221,6 +221,7 @@ export default function MessageDetail({ messageId, onBack, folderRole }: Props) 
   }
 
   const recipientLine = formatRecipients(message.to_list);
+  const ccLine = formatRecipients(message.cc_list);
 
   return (
     <div
@@ -337,7 +338,12 @@ export default function MessageDetail({ messageId, onBack, folderRole }: Props) 
             )}
             {recipientLine && (
               <span style={{ color: "var(--color-text-secondary)", marginLeft: "6px", fontSize: "12px" }}>
-                to&nbsp;{recipientLine}
+                {t("messageDetail.to", "To:")}&nbsp;{recipientLine}
+              </span>
+            )}
+            {ccLine && (
+              <span style={{ color: "var(--color-text-secondary)", marginLeft: "6px", fontSize: "12px" }}>
+                {t("messageDetail.cc", "Cc:")}&nbsp;{ccLine}
               </span>
             )}
           </div>

--- a/src/components/ThreadMessageBubble.tsx
+++ b/src/components/ThreadMessageBubble.tsx
@@ -74,7 +74,14 @@ export default function ThreadMessageBubble({ message, defaultExpanded = false }
         <div style={{ padding: "12px 14px", borderTop: "1px solid var(--color-border)" }}>
           {/* To/Cc line */}
           <div style={{ fontSize: "12px", color: "var(--color-text-secondary)", marginBottom: "8px" }}>
-            {t("thread.to")} {message.to_list?.map((r: { address: string }) => r.address).join(", ")}
+            <div>
+              {t("thread.to")} {message.to_list?.map((r: { address: string }) => r.address).join(", ")}
+            </div>
+            {message.cc_list?.length > 0 && (
+              <div>
+                {t("thread.cc", "Cc:")} {message.cc_list.map((r: { address: string }) => r.address).join(", ")}
+              </div>
+            )}
           </div>
           {/* Body content */}
           {rendered?.html ? (

--- a/src/features/settings/AccountsTab.tsx
+++ b/src/features/settings/AccountsTab.tsx
@@ -1,17 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Plus, Trash2, Mail, Pencil, Plug } from "lucide-react";
+import { Plus, Trash2, Mail, Pencil, Plug, RefreshCw } from "lucide-react";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   deleteAccount,
+  getImapSyncFolders,
   getOAuthAccountProxySetting,
   testAccountConnection,
+  triggerSync,
   updateAccount,
+  updateImapSyncFolders,
   updateOAuthAccountProxySetting,
 } from "@/lib/api";
-import type { Account, AccountProxyMode, ConnectionSecurity } from "@/lib/api";
+import type {
+  Account,
+  AccountProxyMode,
+  ConnectionSecurity,
+  ImapSyncFolderSettings,
+} from "@/lib/api";
 import { useAccountsQuery, accountsQueryKey } from "@/hooks/queries";
 import { useMailStore } from "@/stores/mail.store";
 import { useUIStore, type RealtimeStatus } from "@/stores/ui.store";
@@ -392,6 +400,7 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
   onSaved: () => void;
 }) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const dialogRef = useRef<HTMLDivElement>(null);
   const emailInputRef = useRef<HTMLInputElement>(null);
   const [displayName, setDisplayName] = useState(account.display_name);
@@ -409,9 +418,14 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
   const [proxyHost, setProxyHost] = useState("");
   const [proxyPort, setProxyPort] = useState("");
   const [signature, setSignatureValue] = useState("");
+  const [imapFolderSettings, setImapFolderSettings] = useState<ImapSyncFolderSettings | null>(null);
+  const [selectedImapFolderIds, setSelectedImapFolderIds] = useState<Set<string>>(new Set());
+  const [folderLoading, setFolderLoading] = useState(false);
+  const [folderError, setFolderError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isOAuth = account.provider === "gmail" || account.provider === "outlook";
+  const isImap = account.provider === "imap";
   const isPop3 = account.provider === "pop3";
   const incomingHostLabel = isPop3
     ? t("accountSetup.pop3Host", "POP3 host")
@@ -488,6 +502,20 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
     };
   }, [onClose]);
 
+  async function loadImapFolders() {
+    setFolderLoading(true);
+    setFolderError(null);
+    try {
+      const settings = await getImapSyncFolders(account.id);
+      setImapFolderSettings(settings);
+      setSelectedImapFolderIds(new Set(settings.selected_remote_ids));
+    } catch (err) {
+      setFolderError(extractErrorMessage(err));
+    } finally {
+      setFolderLoading(false);
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
@@ -542,6 +570,28 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
           accountColor,
         );
       }
+
+      if (isImap && imapFolderSettings) {
+        const updatedSettings = await updateImapSyncFolders(
+          account.id,
+          Array.from(selectedImapFolderIds),
+        );
+        setImapFolderSettings(updatedSettings);
+        setSelectedImapFolderIds(new Set(updatedSettings.selected_remote_ids));
+        try {
+          await triggerSync(account.id, "manual");
+        } catch (err) {
+          console.warn("Failed to trigger sync after updating IMAP folders:", err);
+        }
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["folders", account.id] }),
+          queryClient.invalidateQueries({ queryKey: ["messages"] }),
+          queryClient.invalidateQueries({ queryKey: ["threads"] }),
+          queryClient.invalidateQueries({ queryKey: ["folder-unread-counts", account.id] }),
+          queryClient.invalidateQueries({ queryKey: ["starred-messages", account.id] }),
+        ]);
+      }
+
       await setSignature(account.id, signature);
       onSaved();
     } catch (err) {
@@ -780,6 +830,134 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
 
             {proxyFields}
 
+            {isImap && (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "10px",
+                  padding: "12px",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "8px",
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+                  <div>
+                    <div style={{ ...labelStyle, marginBottom: "3px" }}>
+                      {t("settings.syncFolders", "Folders to sync")}
+                    </div>
+                    <div style={{ fontSize: "12px", color: "var(--color-text-secondary)", lineHeight: 1.45 }}>
+                      {t(
+                        "settings.syncFoldersDesc",
+                        "Inbox is always synced. Choose any additional IMAP folders to keep locally.",
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={loadImapFolders}
+                    disabled={folderLoading || loading}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "6px",
+                      padding: "7px 10px",
+                      borderRadius: "6px",
+                      border: "1px solid var(--color-border)",
+                      backgroundColor: "var(--color-bg)",
+                      color: "var(--color-text-primary)",
+                      fontSize: "12px",
+                      cursor: folderLoading || loading ? "wait" : "pointer",
+                      opacity: folderLoading || loading ? 0.7 : 1,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <RefreshCw size={13} aria-hidden="true" />
+                    {folderLoading
+                      ? t("settings.loadingFolders", "Loading...")
+                      : imapFolderSettings
+                        ? t("settings.refreshFolders", "Refresh folders")
+                        : t("settings.chooseFolders", "Choose folders")}
+                  </button>
+                </div>
+
+                {folderError && (
+                  <div role="alert" style={{ color: "#ef4444", fontSize: "12px" }}>
+                    {t("settings.folderListFailed", "Failed to list IMAP folders: {{error}}", {
+                      error: folderError,
+                    })}
+                  </div>
+                )}
+
+                {imapFolderSettings && (
+                  <>
+                    <div
+                      role="group"
+                      aria-label={t("settings.syncFolders", "Folders to sync")}
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "7px",
+                        maxHeight: "180px",
+                        overflowY: "auto",
+                        padding: "9px",
+                        borderRadius: "6px",
+                        backgroundColor: "var(--color-bg-secondary, var(--color-bg-hover))",
+                      }}
+                    >
+                      {imapFolderSettings.folders.map((folder) => {
+                        const isInboxFolder =
+                          folder.role === "inbox" || folder.remote_id.toUpperCase() === "INBOX";
+                        return (
+                          <label
+                            key={folder.remote_id}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "8px",
+                              color: "var(--color-text-primary)",
+                              fontSize: "12px",
+                              cursor: isInboxFolder ? "default" : "pointer",
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              aria-label={folder.name}
+                              checked={isInboxFolder || selectedImapFolderIds.has(folder.remote_id)}
+                              disabled={isInboxFolder}
+                              onChange={(event) => {
+                                setSelectedImapFolderIds((current) => {
+                                  const next = new Set(current);
+                                  if (event.target.checked) {
+                                    next.add(folder.remote_id);
+                                  } else {
+                                    next.delete(folder.remote_id);
+                                  }
+                                  return next;
+                                });
+                              }}
+                            />
+                            <span>{folder.name}</span>
+                            {isInboxFolder && (
+                              <span style={{ color: "var(--color-text-secondary)", marginLeft: "auto" }}>
+                                {t("settings.alwaysSynced", "Always synced")}
+                              </span>
+                            )}
+                          </label>
+                        );
+                      })}
+                    </div>
+                    <div style={{ color: "var(--color-text-secondary)", fontSize: "11px", lineHeight: 1.45 }}>
+                      {t(
+                        "settings.syncFoldersCleanupWarning",
+                        "Saving removes locally stored data for folders you uncheck. It does not delete mail from the server.",
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+
             {/* Signature */}
             <div style={fieldStyle}>
               <label style={labelStyle}>{t("settings.signature", "Signature")} <span style={{ color: "var(--color-text-secondary)", fontWeight: 400 }}>({t("settings.optional", "optional")})</span></label>
@@ -799,7 +977,7 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
 
             <button
               type="submit"
-              disabled={loading}
+              disabled={loading || folderLoading}
               style={{
                 padding: "9px 16px",
                 borderRadius: "6px",
@@ -808,8 +986,8 @@ function EditAccountModal({ account, initialColor, onClose, onSaved }: {
                 color: "#fff",
                 fontSize: "13px",
                 fontWeight: 600,
-                cursor: loading ? "not-allowed" : "pointer",
-                opacity: loading ? 0.7 : 1,
+                cursor: loading || folderLoading ? "not-allowed" : "pointer",
+                opacity: loading || folderLoading ? 0.7 : 1,
                 marginTop: "4px",
               }}
             >

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,6 +14,7 @@ export type {
   EmailAddress,
   Folder,
   HttpProxyConfig,
+  ImapSyncFolderSettings,
   ImportedBackgroundImage,
   KanbanCard,
   KanbanColumnType,
@@ -47,6 +48,7 @@ import type {
   ConnectionSecurity,
   Folder,
   HttpProxyConfig,
+  ImapSyncFolderSettings,
   KanbanCard,
   KanbanColumnType,
   KnownContact,
@@ -245,6 +247,20 @@ export async function deleteAccount(accountId: string): Promise<void> {
 
 export async function listFolders(accountId: string): Promise<Folder[]> {
   return invoke<Folder[]>("list_folders", { accountId });
+}
+
+export async function getImapSyncFolders(accountId: string): Promise<ImapSyncFolderSettings> {
+  return invoke<ImapSyncFolderSettings>("get_imap_sync_folders", { accountId });
+}
+
+export async function updateImapSyncFolders(
+  accountId: string,
+  selectedRemoteIds: string[],
+): Promise<ImapSyncFolderSettings> {
+  return invoke<ImapSyncFolderSettings>("update_imap_sync_folders", {
+    accountId,
+    selectedRemoteIds,
+  });
 }
 
 // ─── Message API ─────────────────────────────────────────────────────────────

--- a/src/lib/ipc-types.ts
+++ b/src/lib/ipc-types.ts
@@ -35,6 +35,12 @@ export interface Folder {
   sort_order: number;
 }
 
+/** @rust src-tauri/src/commands/folders.rs → ImapSyncFolderSettings */
+export interface ImapSyncFolderSettings {
+  folders: Folder[];
+  selected_remote_ids: string[];
+}
+
 /** @rust pebble-core/src/types.rs → EmailAddress */
 export interface EmailAddress {
   name: string | null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -221,6 +221,14 @@
     "optional": "optional",
     "signature": "Signature",
     "signaturePlaceholder": "Your email signature...",
+    "syncFolders": "Folders to sync",
+    "syncFoldersDesc": "Inbox is always synced. Choose any additional IMAP folders to keep locally.",
+    "chooseFolders": "Choose folders",
+    "refreshFolders": "Refresh folders",
+    "loadingFolders": "Loading...",
+    "folderListFailed": "Failed to list IMAP folders: {{error}}",
+    "alwaysSynced": "Always synced",
+    "syncFoldersCleanupWarning": "Saving removes locally stored data for folders you uncheck. It does not delete mail from the server.",
     "oauthAccountNote": "This account uses OAuth. Provider sign-in, password, and IMAP/SMTP settings are managed by the provider. Leave the proxy blank to inherit the global SOCKS5 proxy.",
     "deleteAccountSuccess": "Account removed successfully",
     "deleteAccountFailed": "Failed to remove account"
@@ -664,7 +672,8 @@
   },
   "thread": {
     "title": "Thread",
-    "to": "To:"
+    "to": "To:",
+    "cc": "Cc:"
   },
   "errorBoundary": {
     "title": "Something went wrong",
@@ -697,6 +706,8 @@
     "unstar": "Unstar"
   },
   "messageDetail": {
-    "body": "Message body"
+    "body": "Message body",
+    "to": "To:",
+    "cc": "Cc:"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -216,6 +216,14 @@
     "leaveEmptyKeep": "留空保持不变",
     "signature": "签名",
     "signaturePlaceholder": "输入邮件签名...",
+    "syncFolders": "同步文件夹",
+    "syncFoldersDesc": "收件箱始终同步。请选择还需要保存在本地的其他 IMAP 文件夹。",
+    "chooseFolders": "选择文件夹",
+    "refreshFolders": "刷新文件夹",
+    "loadingFolders": "正在加载...",
+    "folderListFailed": "无法列出 IMAP 文件夹：{{error}}",
+    "alwaysSynced": "始终同步",
+    "syncFoldersCleanupWarning": "保存后会移除未勾选文件夹的本地数据，但不会删除服务器上的邮件。",
     "optional": "可选",
     "oauthAccountNote": "此账户使用 OAuth 登录。服务商登录、密码和 IMAP/SMTP 设置由服务商管理。代理留空时会继承全局 SOCKS5 代理。",
     "deleteAccountSuccess": "账户已成功移除",
@@ -664,7 +672,8 @@
   },
   "thread": {
     "title": "会话",
-    "to": "收件人："
+    "to": "收件人：",
+    "cc": "抄送："
   },
   "errorBoundary": {
     "title": "出了点问题",
@@ -697,6 +706,8 @@
     "unstar": "取消星标"
   },
   "messageDetail": {
-    "body": "邮件正文"
+    "body": "邮件正文",
+    "to": "收件人：",
+    "cc": "抄送："
   }
 }

--- a/tests/components/MessageDetail.selection.test.tsx
+++ b/tests/components/MessageDetail.selection.test.tsx
@@ -16,7 +16,7 @@ const mockMessage: Message = {
   from_address: "sender@example.com",
   from_name: "Sender",
   to_list: [{ name: "Destination", address: "destination@example.com" }],
-  cc_list: [],
+  cc_list: [{ name: "Copied teammate", address: "cc@example.com" }],
   bcc_list: [],
   has_attachments: false,
   is_read: true,
@@ -156,6 +156,7 @@ describe("MessageDetail selected-text context actions", () => {
     render(<MessageDetail messageId="message-1" onBack={vi.fn()} />);
 
     expect(screen.getByText(/destination@example\.com/)).toBeTruthy();
+    expect(screen.getByText(/cc@example\.com/)).toBeTruthy();
     expect(screen.queryByText(/current@example\.com/)).toBeNull();
   });
 });

--- a/tests/components/ThreadMessageBubble.test.tsx
+++ b/tests/components/ThreadMessageBubble.test.tsx
@@ -35,7 +35,7 @@ const message: Message = {
   from_address: "sender@example.com",
   from_name: "Sender",
   to_list: [{ name: null, address: "user@example.com" }],
-  cc_list: [],
+  cc_list: [{ name: null, address: "cc@example.com" }],
   bcc_list: [],
   has_attachments: false,
   is_read: true,
@@ -52,6 +52,12 @@ const message: Message = {
 };
 
 describe("ThreadMessageBubble", () => {
+  it("shows copied recipients when expanded", () => {
+    render(<ThreadMessageBubble message={message} defaultExpanded />);
+
+    expect(document.body.textContent).toContain("Cc: cc@example.com");
+  });
+
   it("uses relaxed privacy mode by default when rendering expanded thread messages", async () => {
     localStorage.removeItem("pebble-privacy-mode");
 

--- a/tests/features/settings/AccountsTab.imap-folders.test.tsx
+++ b/tests/features/settings/AccountsTab.imap-folders.test.tsx
@@ -1,0 +1,174 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AccountsTab from "../../../src/features/settings/AccountsTab";
+import {
+  getImapSyncFolders,
+  triggerSync,
+  updateAccount,
+  updateImapSyncFolders,
+} from "../../../src/lib/api";
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: {
+    type: "3rdParty",
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mocks.invalidateQueries,
+  }),
+}));
+
+vi.mock("../../../src/hooks/queries", () => ({
+  accountsQueryKey: ["accounts"],
+  useAccountsQuery: () => ({
+    data: [
+      {
+        id: "account-1",
+        email: "user@example.com",
+        display_name: "User",
+        provider: "imap",
+        color: "#22c55e",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ],
+  }),
+}));
+
+vi.mock("../../../src/lib/api", () => ({
+  deleteAccount: vi.fn(),
+  getImapSyncFolders: vi.fn(),
+  getOAuthAccountProxySetting: vi.fn(),
+  testAccountConnection: vi.fn(),
+  triggerSync: vi.fn(),
+  updateAccount: vi.fn(),
+  updateImapSyncFolders: vi.fn(),
+  updateOAuthAccountProxySetting: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/signatures", () => ({
+  getSignature: vi.fn(() => Promise.resolve("")),
+  setSignature: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../src/components/AccountSetup", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../../src/stores/mail.store", () => ({
+  useMailStore: {
+    getState: () => ({
+      activeAccountId: null,
+      setActiveAccountId: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../../../src/stores/ui.store", () => ({
+  useUIStore: (selector: (state: { realtimeStatusByAccount: Record<string, unknown> }) => unknown) =>
+    selector({ realtimeStatusByAccount: {} }),
+}));
+
+vi.mock("../../../src/stores/toast.store", () => ({
+  useToastStore: {
+    getState: () => ({
+      addToast: vi.fn(),
+    }),
+  },
+}));
+
+const folderSettings = {
+  folders: [
+    {
+      id: "inbox-id",
+      account_id: "account-1",
+      remote_id: "INBOX",
+      name: "Inbox",
+      folder_type: "folder" as const,
+      role: "inbox" as const,
+      parent_id: null,
+      color: null,
+      is_system: true,
+      sort_order: 0,
+    },
+    {
+      id: "sent-id",
+      account_id: "account-1",
+      remote_id: "Sent",
+      name: "Sent",
+      folder_type: "folder" as const,
+      role: "sent" as const,
+      parent_id: null,
+      color: null,
+      is_system: true,
+      sort_order: 1,
+    },
+    {
+      id: "projects-id",
+      account_id: "account-1",
+      remote_id: "Projects",
+      name: "Projects",
+      folder_type: "folder" as const,
+      role: null,
+      parent_id: null,
+      color: null,
+      is_system: true,
+      sort_order: 10,
+    },
+  ],
+  selected_remote_ids: ["INBOX", "Sent"],
+};
+
+describe("AccountsTab IMAP folder selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getImapSyncFolders).mockResolvedValue(folderSettings);
+    vi.mocked(updateImapSyncFolders).mockImplementation(
+      async (_accountId, selectedRemoteIds) => ({
+        ...folderSettings,
+        selected_remote_ids: selectedRemoteIds,
+      }),
+    );
+    vi.mocked(updateAccount).mockResolvedValue(undefined);
+    vi.mocked(triggerSync).mockResolvedValue(undefined);
+  });
+
+  it("lists folders, locks Inbox, and saves additional selections", async () => {
+    render(<AccountsTab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit account" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose folders" }));
+
+    await waitFor(() => {
+      expect(getImapSyncFolders).toHaveBeenCalledWith("account-1");
+    });
+
+    const inbox = await screen.findByRole("checkbox", { name: "Inbox" });
+    const sent = screen.getByRole("checkbox", { name: "Sent" });
+    const projects = screen.getByRole("checkbox", { name: "Projects" });
+    expect((inbox as HTMLInputElement).checked).toBe(true);
+    expect((inbox as HTMLInputElement).disabled).toBe(true);
+
+    fireEvent.click(sent);
+    fireEvent.click(projects);
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => {
+      expect(updateImapSyncFolders).toHaveBeenCalledWith("account-1", [
+        "INBOX",
+        "Projects",
+      ]);
+    });
+    expect(triggerSync).toHaveBeenCalledWith("account-1", "manual");
+  });
+});

--- a/tests/hooks/useFoldersQuery.test.ts
+++ b/tests/hooks/useFoldersQuery.test.ts
@@ -8,7 +8,11 @@ import { invoke } from "@tauri-apps/api/core";
 const mockInvoke = vi.mocked(invoke);
 
 import { foldersQueryKey } from "../../src/hooks/queries/useFoldersQuery";
-import { listFolders } from "../../src/lib/api";
+import {
+  getImapSyncFolders,
+  listFolders,
+  updateImapSyncFolders,
+} from "../../src/lib/api";
 
 describe("useFoldersQuery", () => {
   beforeEach(() => {
@@ -52,5 +56,24 @@ describe("useFoldersQuery", () => {
 
     expect(result).toEqual(mockFolders);
     expect(mockInvoke).toHaveBeenCalledWith("list_folders", { accountId: "a1" });
+  });
+
+  it("discovers and updates the selected IMAP folders", async () => {
+    const settings = {
+      folders: [],
+      selected_remote_ids: ["INBOX"],
+    };
+    mockInvoke.mockResolvedValueOnce(settings).mockResolvedValueOnce(settings);
+
+    await expect(getImapSyncFolders("a1")).resolves.toEqual(settings);
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "get_imap_sync_folders", {
+      accountId: "a1",
+    });
+
+    await expect(updateImapSyncFolders("a1", ["INBOX"])).resolves.toEqual(settings);
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "update_imap_sync_folders", {
+      accountId: "a1",
+      selectedRemoteIds: ["INBOX"],
+    });
   });
 });


### PR DESCRIPTION
## 功能

- 在邮件详情和会话邮件中显示抄送（CC）对象，并补充中英文文案和组件测试。
- 在 IMAP 账号编辑页通过 LIST 获取服务器文件夹，支持勾选需要同步的文件夹；Inbox 始终同步。
- 兼容已有账号的历史同步行为；保存选择后，新增文件夹会加入同步，取消选择的文件夹只清理本地数据，不影响服务器。

## 验证

- Rust: rustfmt、Clippy、workspace/all-targets tests 通过（454 passed，2 ignored）。
- Frontend: 88 个测试文件、333 项测试通过。
- Windows x64 NSIS、macOS ARM64 app/dmg、Linux AppImage/deb/rpm 均已完成自动打包验证。
- 验证运行：https://github.com/pcjiang1998/Pebble/actions/runs/30378511971

Closes #74
Closes #82